### PR TITLE
fixed tab typo

### DIFF
--- a/netattack2.py
+++ b/netattack2.py
@@ -34,7 +34,7 @@ def auto_installer():
         subprocess.call("sudo apt-get install python-scapy -y > {}".format(os.devnull), shell=True)
         subprocess.call("sudo apt-get install python-nmap -y > {}".format(os.devnull), shell=True)
         subprocess.call("sudo apt-get install python-nfqueue -y > {}".format(os.devnull), shell=True)
-	subprocess.call("sudo apt-get install nmap -y > {}".format(os.devnull), shell=True)
+        subprocess.call("sudo apt-get install nmap -y > {}".format(os.devnull), shell=True)
         sys.exit("\n[{G}+{N}] Requirements installed.\n".format(G=GREEN, N=NORMAL))
 
     sys.exit(0)


### PR DESCRIPTION
Fixed line 37:
```
python netattack2.py 
  File "/tmp/netattack2/netattack2.py", line 37
    subprocess.call("sudo apt-get install nmap -y > {}".format(os.devnull), shell=True)
TabError: inconsistent use of tabs and spaces in indentation

```